### PR TITLE
add GCP Artifact Registry build and push workflow

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -1,0 +1,42 @@
+name: Build and Push to GCP Artifact Registry
+
+on:
+  push:
+    branches:
+      - gcp
+  pull_request:
+    branches:
+      - gcp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Build, tag, and push image
+        env:
+          GCP_REGION: ${{ secrets.GCP_REGION }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          AR_REPOSITORY: ${{ secrets.GCP_AR_REPOSITORY }}
+          IMAGE_NAME: cv-site-nextjs
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE_PATH=$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPOSITORY/$IMAGE_NAME
+          docker build -t $IMAGE_PATH:$IMAGE_TAG .
+          docker push $IMAGE_PATH:$IMAGE_TAG
+          docker tag $IMAGE_PATH:$IMAGE_TAG $IMAGE_PATH:latest
+          docker push $IMAGE_PATH:latest


### PR DESCRIPTION
Mirrors the existing ECR workflow but targets Google Artifact Registry. Triggers on push and pull_request to the gcp branch.